### PR TITLE
Fix references after dataclass refactor

### DIFF
--- a/firstshot/entities/blast.py
+++ b/firstshot/entities/blast.py
@@ -12,7 +12,7 @@ class Blast:
         self.radius = Blast.START_RADIUS  # 爆発の半径
 
         # ゲームの爆発エフェクトリストに登録する
-        game.blasts.append(self)
+        game.enemy_state.blasts.append(self)
 
     # 爆発エフェクトを更新する
     def update(self):
@@ -21,7 +21,7 @@ class Blast:
 
         # 半径が最大になったら爆発エフェクトリストから登録を削除する
         if self.radius > Blast.END_RADIUS:
-            self.game.blasts.remove(self)
+            self.game.enemy_state.blasts.remove(self)
 
     # 爆発エフェクトを描画する
     def draw(self):

--- a/firstshot/entities/bullet.py
+++ b/firstshot/entities/bullet.py
@@ -20,7 +20,7 @@ class Bullet:
             game.player_state.bullets.append(self)
         else:
             self.hit_area = (2, 2, 5, 5)
-            game.enemy_bullets.append(self)
+            game.enemy_state.bullets.append(self)
 
     # 弾にダメージを与える
     def add_damage(self):
@@ -29,8 +29,8 @@ class Bullet:
             if self in self.game.player_state.bullets:  # 自機の弾リストに登録されている時
                 self.game.player_state.bullets.remove(self)
         else:
-            if self in self.game.enemy_bullets:  # 敵の弾リストに登録されている時
-                self.game.enemy_bullets.remove(self)
+            if self in self.game.enemy_state.bullets:  # 敵の弾リストに登録されている時
+                self.game.enemy_state.bullets.remove(self)
 
     # 弾を更新する
     def update(self):
@@ -48,7 +48,7 @@ class Bullet:
             if self.side == Bullet.SIDE_PLAYER:
                 self.game.player_state.bullets.remove(self)
             else:
-                self.game.enemy_bullets.remove(self)
+                self.game.enemy_state.bullets.remove(self)
 
     # 弾を描画する
     def draw(self):

--- a/firstshot/entities/enemies/enemy.py
+++ b/firstshot/entities/enemies/enemy.py
@@ -48,9 +48,9 @@ class Enemy:
             self.game.enemy_state.enemies.remove(self)
 
         # スコアを加算する
-        self.game.score += self.level * 10
+        self.game.game_data.score += self.level * 10
         # パイロット毎に経験値を加算する
-        if self.game.pilot_kind == PILOT_CLARICE:
+        if self.game.player_state.pilot_kind == PILOT_CLARICE:
             self.game.player_state.exp += self.level * 1.1
         else:
             self.game.player_state.exp += self.level * 1

--- a/firstshot/entities/enemies/enemy_stage1_boss.py
+++ b/firstshot/entities/enemies/enemy_stage1_boss.py
@@ -35,12 +35,12 @@ class StageOneBoss(Enemy):
             self.game.enemy_state.enemies.remove(self)
 
         # スコアを加算する
-        self.game.score += self.level * 10
+        self.game.game_data.score += self.level * 10
         # 経験値を加算する
         self.game.player_state.exp += self.level * 1
 
         # ボス撃破フラグをTrueにする
-        self.game.boss_destroy_flag = True
+        self.game.boss_state.destroyed = True
 
     # 敵を更新する
     def update(self):
@@ -69,4 +69,4 @@ class StageOneBoss(Enemy):
 
     # 敵を描画する
     def draw(self):
-        pyxel.blt(self.x, self.y, self.game.boss_image, 0, 0, 64, 64, 188)
+        pyxel.blt(self.x, self.y, self.game.boss_state.image, 0, 0, 64, 64, 188)

--- a/firstshot/entities/enemies/enemy_stage2_boss_left.py
+++ b/firstshot/entities/enemies/enemy_stage2_boss_left.py
@@ -35,12 +35,12 @@ class StageTwoBossLeft(Enemy):
             self.game.enemy_state.enemies.remove(self)
 
         # スコアを加算する
-        self.game.score += self.level * 10
+        self.game.game_data.score += self.level * 10
         # 経験値を加算する
         self.game.player_state.exp += self.level * 1
 
         # ボス撃破フラグをTrueにする
-        self.game.boss_destroy_flag = True
+        self.game.boss_state.destroyed = True
 
     # 敵を更新する
     def update(self):
@@ -64,4 +64,4 @@ class StageTwoBossLeft(Enemy):
 
     # 敵を描画する
     def draw(self):
-        pyxel.blt(self.x, self.y, self.game.boss_image, 0, 24, 64, 80,188)
+        pyxel.blt(self.x, self.y, self.game.boss_state.image, 0, 24, 64, 80, 188)

--- a/firstshot/entities/enemies/enemy_stage2_boss_right.py
+++ b/firstshot/entities/enemies/enemy_stage2_boss_right.py
@@ -35,12 +35,12 @@ class StageTwoBossRight(Enemy):
             self.game.enemy_state.enemies.remove(self)
 
         # スコアを加算する
-        self.game.score += self.level * 10
+        self.game.game_data.score += self.level * 10
         # 経験値を加算する
         self.game.player_state.exp += self.level * 1
 
         # ボス撃破フラグをTrueにする
-        self.game.boss_destroy_flag = True
+        self.game.boss_state.destroyed = True
 
     # 敵を更新する
     def update(self):
@@ -67,4 +67,4 @@ class StageTwoBossRight(Enemy):
 
     # 敵を描画する
     def draw(self):
-        pyxel.blt(self.x, self.y, self.game.boss_image, 64, 24, 60, 80, 188)
+        pyxel.blt(self.x, self.y, self.game.boss_state.image, 64, 24, 60, 80, 188)

--- a/firstshot/scenes/scenes_play_stage/play_scene.py
+++ b/firstshot/scenes/scenes_play_stage/play_scene.py
@@ -15,20 +15,20 @@ class PlayScene:
         # プレイ状態を初期化する
         self.game.enemy_state.enemies = []  # 敵のリスト
         self.game.player_state.bullets = []  # 自機の弾のリスト
-        self.game.enemy_bullets = []  # 敵の弾のリスト
-        self.game.blasts = []  # 爆発エフェクトのリスト
-        self.game.boss_emerge_flag = False  # ボスフラグ
-        self.game.boss_destroy_flag = False  # ボス撃破フラグ
-        self.game.boss_alert = 0 # ボスアラートの表示時間
+        self.game.enemy_state.bullets = []  # 敵の弾のリスト
+        self.game.enemy_state.blasts = []  # 爆発エフェクトのリスト
+        self.game.boss_state.active = False  # ボスフラグ
+        self.game.boss_state.destroyed = False  # ボス撃破フラグ
+        self.game.boss_state.alert_timer = 0  # ボスアラートの表示時間
 
         pyxel.stop()  # BGMの再生を止める
         pygame.mixer.music.stop()  # 停止
 
 
     def update(self):
-        self.game.play_time += 1  # プレイ時間をカウントする
+        self.game.game_data.play_time += 1  # プレイ時間をカウントする
         # 30秒(毎秒30フレームx30)毎に難易度を1上げる
-        self.game.level = self.game.play_time // 900 + 1
+        self.game.game_data.difficulty_level = self.game.game_data.play_time // 900 + 1
 
         # 自機を更新する
         if self.game.player_state.instance is not None:
@@ -57,7 +57,7 @@ class PlayScene:
                         self.game.player_state.instance.sound_timer = 5  # 弾発射音を止める時間を設定する
 
         # 敵の弾を更新する
-        for bullet in self.game.enemy_bullets.copy():
+        for bullet in self.game.enemy_state.bullets.copy():
             bullet.update()
 
             # プレイヤーと敵の弾の当たり判定を行う
@@ -66,7 +66,7 @@ class PlayScene:
                 self.game.player_state.instance.add_damage()  # 自機にダメージを与える
 
         # 爆発エフェクトを更新する
-        for blast in self.game.blasts.copy():
+        for blast in self.game.enemy_state.blasts.copy():
             blast.update()
 
     def draw(self):
@@ -84,14 +84,14 @@ class PlayScene:
             bullet.draw()
 
         # 敵の弾を描画する
-        for bullet in self.game.enemy_bullets:
+        for bullet in self.game.enemy_state.bullets:
             bullet.draw()
 
         # 爆発エフェクトを描画する
-        for blast in self.game.blasts:
+        for blast in self.game.enemy_state.blasts:
             blast.draw()
 
         # ボスアラートの表示時間が0より大きい場合
-        if self.game.boss_alert > 0:
-            self.game.boss_alert -= 1
-            pyxel.text(100, 128, "BOSS",pyxel.rndi(0, 240) , self.game.font)
+        if self.game.boss_state.alert_timer > 0:
+            self.game.boss_state.alert_timer -= 1
+            pyxel.text(100, 128, "BOSS", pyxel.rndi(0, 240), self.game.font)

--- a/firstshot/scenes/scenes_play_stage/stage_one_scene.py
+++ b/firstshot/scenes/scenes_play_stage/stage_one_scene.py
@@ -15,9 +15,9 @@ class StageOneScene(PlayScene):
 
         # プレイ状態を初期化する
         super().start()
-        self.game.score = 0  # スコアを0に戻す
-        self.game.play_time = 0  # プレイ時間を0に戻す
-        self.game.level = 1  # 難易度レベルを1に戻す
+        self.game.game_data.score = 0  # スコアを0に戻す
+        self.game.game_data.play_time = 0  # プレイ時間を0に戻す
+        self.game.game_data.difficulty_level = 1  # 難易度レベルを1に戻す
         self.game.player_state.exp = 0  # プレイヤー経験値を0に戻す
         self.game.player_state.lv = 1  # プレイヤーレベルを1に戻す
 
@@ -26,7 +26,9 @@ class StageOneScene(PlayScene):
         # エネミー画像を切り替え
         pyxel.images[0].load(0, 16, "assets/enemy/enemy_sheet2_size64.png")
         # ボス画像を切り替え
-        self.game.boss_image = pyxel.Image.from_image("assets/enemy/boss_sheet_size192.png", incl_colors=False)
+        self.game.boss_state.image = pyxel.Image.from_image(
+            "assets/enemy/boss_sheet_size192.png", incl_colors=False
+        )
 
         # BGMを再生する
         pyxel.playm(1, loop=True)
@@ -37,29 +39,29 @@ class StageOneScene(PlayScene):
     def update(self):
 
         # ボス撃破フラグをTrueの場合、次のステージに移行する
-        if self.game.boss_destroy_flag:
+        if self.game.boss_state.destroyed:
             self.game.change_scene(SCENE_PLAY_STAGE_TWO)
             return
 
         # 60秒経過後にボスフラグをオンにする
-        if not self.game.boss_emerge_flag and self.game.play_time >= 180:
-            self.game.boss_emerge_flag = True  # ボスフラグ
+        if not self.game.boss_state.active and self.game.game_data.play_time >= 180:
+            self.game.boss_state.active = True  # ボスフラグ
 
         # ボスフラグがオフの時、ザコ敵を出現させる
-        if not self.game.boss_emerge_flag:
-            spawn_interval = max(90 - self.game.level * 10, 20)
-            if self.game.play_time % spawn_interval == 0:
+        if not self.game.boss_state.active:
+            spawn_interval = max(90 - self.game.game_data.difficulty_level * 10, 20)
+            if self.game.game_data.play_time % spawn_interval == 0:
                 kind = pyxel.rndi(0, 2)
                 if kind == 0:
-                    Zigzag(self.game, self.game.level, pyxel.rndi(16, 180), -8)
+                    Zigzag(self.game, self.game.game_data.difficulty_level, pyxel.rndi(16, 180), -8)
                 elif kind == 1:
-                    AroundShooter(self.game, self.game.level, pyxel.rndi(16, 180), -8)
+                    AroundShooter(self.game, self.game.game_data.difficulty_level, pyxel.rndi(16, 180), -8)
                 elif kind == 2:
-                    PlayerShooter(self.game, self.game.level, pyxel.rndi(16, 180), -8)
+                    PlayerShooter(self.game, self.game.game_data.difficulty_level, pyxel.rndi(16, 180), -8)
 
         # ボスフラグがオン　AND　ボスが未出現の時
-        elif self.game.boss_emerge_flag and not any(isinstance(x, StageOneBoss) for x in self.game.enemy_state.enemies.copy()):
-            self.game.boss_alert = 180 #ボスアラートの表示時間を設定
+        elif self.game.boss_state.active and not any(isinstance(x, StageOneBoss) for x in self.game.enemy_state.enemies.copy()):
+            self.game.boss_state.alert_timer = 180  # ボスアラートの表示時間を設定
             StageOneBoss(self.game, 50, 78, -64) # ボスを出現させる
 
         # 親クラスのメソッド実行
@@ -77,6 +79,6 @@ class StageOneScene(PlayScene):
         pyxel.rect(201, 1, 54, 254, 188)
         # 各情報を描画する
         pyxel.text(210, 32, "SCORE", 0, self.game.font)
-        pyxel.text(210, 48, f"{self.game.score:05}", 0, self.game.font)
+        pyxel.text(210, 48, f"{self.game.game_data.score:05}", 0, self.game.font)
         pyxel.text(210, 112, f"EXP {self.game.player_state.exp}", 0, self.game.font)
         pyxel.text(210, 128, f"LV {self.game.player_state.lv}", 0, self.game.font)

--- a/firstshot/scenes/scenes_play_stage/stage_two_scene.py
+++ b/firstshot/scenes/scenes_play_stage/stage_two_scene.py
@@ -20,7 +20,9 @@ class StageTwoScene(PlayScene):
         # エネミー画像を切り替え
         pyxel.images[0].load(0, 16, "assets/enemy/enemy_stage2.png")
         # ボス画像を切り替え
-        self.game.boss_image = pyxel.Image.from_image("assets/enemy/boss_stage2.png", incl_colors=False)
+        self.game.boss_state.image = pyxel.Image.from_image(
+            "assets/enemy/boss_stage2.png", incl_colors=False
+        )
 
         # BGMを再生する
         pygame.mixer.music.load("assets/bgm/stage1_ba-dakkuman.ogg")  # 音楽ファイルを読み込む
@@ -30,29 +32,29 @@ class StageTwoScene(PlayScene):
     def update(self):
 
         # 60秒経過後にボスフラグをオンにする
-        if not self.game.boss_emerge_flag and self.game.play_time >= 300:
-            self.game.boss_emerge_flag = True  # ボスフラグ
+        if not self.game.boss_state.active and self.game.game_data.play_time >= 300:
+            self.game.boss_state.active = True  # ボスフラグ
 
         # ボスフラグがオフの時、ザコ敵を出現させる
-        if not self.game.boss_emerge_flag:
-            spawn_interval = max(90 - self.game.level * 10, 20)
-            if self.game.play_time % spawn_interval == 0:
+        if not self.game.boss_state.active:
+            spawn_interval = max(90 - self.game.game_data.difficulty_level * 10, 20)
+            if self.game.game_data.play_time % spawn_interval == 0:
                 kind = pyxel.rndi(0, 2)
                 if kind == 0:
-                    RobotFollow(self.game, self.game.level, pyxel.rndi(16, 180), -8)
+                    RobotFollow(self.game, self.game.game_data.difficulty_level, pyxel.rndi(16, 180), -8)
                 elif kind == 1:
-                    RobotAroundShooter(self.game, self.game.level, pyxel.rndi(16, 180), -8)
+                    RobotAroundShooter(self.game, self.game.game_data.difficulty_level, pyxel.rndi(16, 180), -8)
                 elif kind == 2:
-                    RobotPlayerShooter(self.game, self.game.level, pyxel.rndi(16, 180), -8)
+                    RobotPlayerShooter(self.game, self.game.game_data.difficulty_level, pyxel.rndi(16, 180), -8)
 
         # ボスフラグがオン　AND　ボスが未出現の時
-        elif self.game.boss_emerge_flag and not any(isinstance(x, StageTwoBossLeft) for x in self.game.enemy_state.enemies.copy()):
-            self.game.boss_alert = 180 #ボスアラートの表示時間を設定
+        elif self.game.boss_state.active and not any(isinstance(x, StageTwoBossLeft) for x in self.game.enemy_state.enemies.copy()):
+            self.game.boss_state.alert_timer = 180  # ボスアラートの表示時間を設定
             StageTwoBossLeft(self.game, 50, 18, -64) # ボスを出現させる
 
         # ボスフラグがオン　AND　ボスが未出現の時
-        elif self.game.boss_emerge_flag and not any(isinstance(x, StageTwoBossRight) for x in self.game.enemy_state.enemies.copy()):
-            self.game.boss_alert = 180  # ボスアラートの表示時間を設定
+        elif self.game.boss_state.active and not any(isinstance(x, StageTwoBossRight) for x in self.game.enemy_state.enemies.copy()):
+            self.game.boss_state.alert_timer = 180  # ボスアラートの表示時間を設定
             StageTwoBossRight(self.game, 50, 118, -64)  # ボスを出現させる
 
         # 親クラスのメソッド実行
@@ -70,6 +72,6 @@ class StageTwoScene(PlayScene):
         pyxel.rect(201, 1, 54, 254, 188)
         # 各情報を描画する
         pyxel.text(210, 32, "SCORE", 0, self.game.font)
-        pyxel.text(210, 48, f"{self.game.score:05}", 0, self.game.font)
+        pyxel.text(210, 48, f"{self.game.game_data.score:05}", 0, self.game.font)
         pyxel.text(210, 112, f"EXP {self.game.player_state.exp}", 0, self.game.font)
         pyxel.text(210, 128, f"LV {self.game.player_state.lv}", 0, self.game.font)

--- a/firstshot/scenes/select_pilot_scene.py
+++ b/firstshot/scenes/select_pilot_scene.py
@@ -48,7 +48,7 @@ class SelectPilotScene:
 
         if pyxel.btnp(pyxel.KEY_RETURN):
             # パイロットの種類をgameに登録
-            self.game.pilot_kind = self.pilot_kind
+            self.game.player_state.pilot_kind = self.pilot_kind
 
             pyxel.stop()  # BGMの再生を止める
             # プレイ画面に遷移

--- a/firstshot/scenes/title_scene.py
+++ b/firstshot/scenes/title_scene.py
@@ -17,8 +17,8 @@ class TitleScene:
         # 全ての弾と敵を削除する
         self.game.enemy_state.enemies = []  # 敵のリスト
         self.game.player_state.bullets = []  # 自機の弾のリスト
-        self.game.enemy_bullets = []  # 敵の弾のリスト
-        self.game.blasts = []  # 爆発エフェクトのリスト
+        self.game.enemy_state.bullets = []  # 敵の弾のリスト
+        self.game.enemy_state.blasts = []  # 爆発エフェクトのリスト
 
         # BGMを再生する
         pyxel.playm(0, loop=True)


### PR DESCRIPTION
## Summary
- update entity lists and score tracking to use dataclass fields
- adjust boss state handling using BossState dataclass
- fix pilot selection to update PlayerState
- update play scenes to use GameData

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6841522020d483289e98182df23fed2b