### PR TITLE
Add extensive unit tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,9 @@
+import os
+import sys
+
+# Add project root to path
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+# Insert pyxel stub
+from tests import pyxel_stub
+sys.modules['pyxel'] = pyxel_stub

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -1,0 +1,15 @@
+from firstshot.game_data import PlayerState, EnemyState, BossState, GameData
+
+class DummyGame:
+    def __init__(self):
+        self.game_data = GameData()
+        self.player_state = PlayerState()
+        self.enemy_state = EnemyState()
+        self.boss_state = BossState()
+        self.display_timer = 0
+        self.font = None
+        self.changed_scene_to = None
+
+    def change_scene(self, scene_name):
+        self.changed_scene_to = scene_name
+        self.game_data.scene_name = scene_name

--- a/tests/pyxel_stub.py
+++ b/tests/pyxel_stub.py
@@ -1,0 +1,116 @@
+import math
+import random
+
+width = 256
+height = 256
+
+KEY_LEFT = 1
+KEY_RIGHT = 2
+KEY_UP = 3
+KEY_DOWN = 4
+KEY_SPACE = 5
+KEY_RETURN = 6
+KEY_E = 7
+
+_btn = set()
+_btnp = set()
+
+def btn(key):
+    return key in _btn
+
+def btnp(key):
+    if key in _btnp:
+        _btnp.remove(key)
+        return True
+    return False
+
+def set_btn(key, value=True):
+    if value:
+        _btn.add(key)
+    else:
+        _btn.discard(key)
+
+def set_btnp(key, value=True):
+    if value:
+        _btnp.add(key)
+    else:
+        _btnp.discard(key)
+
+def cos(angle):
+    return math.cos(math.radians(angle))
+
+def sin(angle):
+    return math.sin(math.radians(angle))
+
+def atan2(y, x):
+    return math.degrees(math.atan2(y, x))
+
+def rndi(a, b):
+    return random.randint(a, b)
+
+
+def rndf(a, b):
+    return random.uniform(a, b)
+
+
+def stop():
+    pass
+
+
+def quit():
+    pass
+
+
+def play(*a, **k):
+    pass
+
+
+def playm(*a, **k):
+    pass
+
+
+def text(*a, **k):
+    pass
+
+
+def blt(*a, **k):
+    pass
+
+
+def circ(*a, **k):
+    pass
+
+
+def circb(*a, **k):
+    pass
+
+
+def pset(*a, **k):
+    pass
+
+
+def rect(*a, **k):
+    pass
+
+
+def rectb(*a, **k):
+    pass
+
+
+def cls(*a, **k):
+    pass
+
+
+class Image:
+    def __init__(self, w=0, h=0):
+        self.w = w
+        self.h = h
+
+    def load(self, x, y, filename):
+        pass
+
+    @staticmethod
+    def from_image(filename, incl_colors=False):
+        return Image()
+images = [Image(256,256), Image(256,256), Image(256,256)]
+

--- a/tests/test_dialog.py
+++ b/tests/test_dialog.py
@@ -1,0 +1,58 @@
+import sys
+import types
+import pyxel
+from tests.helpers import DummyGame
+from firstshot.logic.dialog import display_exit_dialog
+
+
+def test_display_exit_dialog_yes(monkeypatch):
+    game = DummyGame()
+    quit_called = {}
+    monkeypatch.setattr(pyxel, "quit", lambda: quit_called.setdefault("q", True))
+
+    class DummyBox:
+        def askyesno(self, title=None, message=None):
+            return True
+
+    class DummyTk:
+        def withdraw(self):
+            pass
+
+        def destroy(self):
+            pass
+
+    tk_module = types.ModuleType("tkinter")
+    tk_module.Tk = lambda: DummyTk()
+    mb_module = types.ModuleType("tkinter.messagebox")
+    mb_module.askyesno = DummyBox().askyesno
+    monkeypatch.setitem(sys.modules, "tkinter", tk_module)
+    monkeypatch.setitem(sys.modules, "tkinter.messagebox", mb_module)
+    display_exit_dialog(game)
+    assert quit_called
+
+
+def test_display_exit_dialog_no(monkeypatch):
+    game = DummyGame()
+    game.game_data.is_exit_mode = True
+    monkeypatch.setattr(pyxel, "quit", lambda: None)
+
+    class DummyBox:
+        def askyesno(self, title=None, message=None):
+            return False
+
+    class DummyTk:
+        def withdraw(self):
+            pass
+
+        def destroy(self):
+            pass
+
+    tk_module = types.ModuleType("tkinter")
+    tk_module.Tk = lambda: DummyTk()
+    mb_module = types.ModuleType("tkinter.messagebox")
+    mb_module.askyesno = DummyBox().askyesno
+    monkeypatch.setitem(sys.modules, "tkinter", tk_module)
+    monkeypatch.setitem(sys.modules, "tkinter.messagebox", mb_module)
+    display_exit_dialog(game)
+    assert game.game_data.is_exit_mode is False
+

--- a/tests/test_entities.py
+++ b/tests/test_entities.py
@@ -1,0 +1,170 @@
+import types
+import pytest
+import pyxel
+
+from firstshot.entities import Blast, Bullet, Player
+from firstshot.entities.enemies import (
+    Enemy,
+    Zigzag,
+    AroundShooter,
+    PlayerShooter,
+    RobotAroundShooter,
+    RobotPlayerShooter,
+    RobotFollow,
+)
+from firstshot.entities.enemies.enemy_stage1_boss import StageOneBoss
+from firstshot.entities.enemies.enemy_stage2_boss_left import StageTwoBossLeft
+from firstshot.entities.enemies.enemy_stage2_boss_right import StageTwoBossRight
+from firstshot.constants import SCENE_GAMEOVER, SCENE_PLAY_STAGE_ONE
+from tests.helpers import DummyGame
+
+
+def reset_inputs():
+    for key in [pyxel.KEY_LEFT, pyxel.KEY_RIGHT, pyxel.KEY_UP, pyxel.KEY_DOWN, pyxel.KEY_SPACE, pyxel.KEY_RETURN, pyxel.KEY_E]:
+        pyxel.set_btn(key, False)
+        pyxel.set_btnp(key, False)
+
+
+def test_blast_update_removes_when_radius_exceeds():
+    game = DummyGame()
+    blast = Blast(game, 0, 0)
+    blast.radius = blast.END_RADIUS
+    blast.update()
+    assert blast not in game.enemy_state.blasts
+
+
+def test_bullet_add_damage_removes_from_list():
+    game = DummyGame()
+    b = Bullet(game, Bullet.SIDE_PLAYER, 0, 0, 0, 0)
+    assert b in game.player_state.bullets
+    b.add_damage()
+    assert b not in game.player_state.bullets
+
+
+def test_bullet_update_moves_and_removes_offscreen():
+    game = DummyGame()
+    b = Bullet(game, Bullet.SIDE_PLAYER, 0, 0, 0, 1)
+    b.update()
+    assert b.x != 0
+    b.x = pyxel.width + 10
+    b.update()
+    assert b not in game.player_state.bullets
+
+
+def test_player_add_damage_triggers_gameover():
+    game = DummyGame()
+    p = Player(game, 0, 0)
+    p.add_damage()
+    assert game.player_state.instance is None
+    assert game.changed_scene_to == SCENE_GAMEOVER
+    assert len(game.enemy_state.blasts) == 1
+
+
+def test_player_update_level_up_and_shoot():
+    game = DummyGame()
+    p = Player(game, 0, 0)
+    game.player_state.exp = 8
+    pyxel.set_btn(pyxel.KEY_SPACE, True)
+    p.update()
+    pyxel.set_btn(pyxel.KEY_SPACE, False)
+    assert game.player_state.lv == 2
+    assert len(game.player_state.bullets) == 1
+    assert p.shot_timer == p.shot_interval
+
+
+def test_enemy_add_damage_and_destroy():
+    game = DummyGame()
+    game.game_data.scene_name = SCENE_PLAY_STAGE_ONE
+    e = Enemy(game, 2, 0, 0)
+    e.add_damage()
+    assert e.armor == 0 and e in game.enemy_state.enemies
+    e.add_damage()
+    assert e not in game.enemy_state.enemies
+    assert len(game.enemy_state.blasts) == 1
+    assert game.game_data.score > 0
+
+
+def test_enemy_calc_player_angle_and_delete_out():
+    game = DummyGame()
+    e = Enemy(game, 1, 0, pyxel.height + 1)
+    angle_no_player = e.calc_player_angle(0, 0)
+    assert angle_no_player == 90
+    Player(game, 10, 0)
+    angle_with_player = e.calc_player_angle(0, 0)
+    assert angle_with_player == pyxel.atan2(-0, 10)
+    e.delete_out_enemy()
+    assert e not in game.enemy_state.enemies
+
+
+def test_zigzag_update_moves():
+    game = DummyGame()
+    z = Zigzag(game, 1, 0, 0)
+    z.update()
+    assert z.y == 1
+    assert z.x != 0
+
+
+def test_enemy_shooters_spawn_bullets():
+    game = DummyGame()
+    a = AroundShooter(game, 1, 0, 0)
+    a.life_time = 39
+    a.update()
+    assert len(game.enemy_state.bullets) == 4
+
+    ps = PlayerShooter(game, 1, 0, 0)
+    ps.life_time = 49
+    ps.update()
+    assert len(game.enemy_state.bullets) == 5
+
+    ra = RobotAroundShooter(game, 1, 0, 0)
+    ra.life_time = 39
+    ra.update()
+    assert len(game.enemy_state.bullets) == 11
+
+    rp = RobotPlayerShooter(game, 1, 0, 0)
+    rp.life_time = 29
+    rp.update()
+    assert len(game.enemy_state.bullets) == 12
+
+
+def test_robot_follow_chases_player():
+    game = DummyGame()
+    Player(game, 10, 10)
+    rf = RobotFollow(game, 1, 0, 0)
+    rf.update()
+    assert rf.x == 1 and rf.y == 1
+
+
+def test_bosses_update_and_damage():
+    game = DummyGame()
+    boss1 = StageOneBoss(game, 50, 0, 0)
+    boss1.life_time = 29
+    boss1.update()
+    assert len(game.enemy_state.bullets) == 8
+    boss1.armor = 1
+    boss1.add_damage()
+    boss1.add_damage()
+    assert game.boss_state.destroyed
+
+    game.enemy_state.bullets.clear()
+    game.boss_state.destroyed = False
+    left = StageTwoBossLeft(game, 50, 0, 0)
+    left.life_time = 29
+    left.update()
+    assert len(game.enemy_state.bullets) >= 8
+    left.armor = 1
+    left.add_damage()
+    left.add_damage()
+    assert game.boss_state.destroyed
+
+    game.enemy_state.bullets.clear()
+    game.boss_state.destroyed = False
+    right = StageTwoBossRight(game, 50, 0, 0)
+    right.life_time = 29
+    right.update()
+    assert len(game.enemy_state.bullets) >= 1
+    right.armor = 1
+    right.add_damage()
+    right.add_damage()
+    assert game.boss_state.destroyed
+

--- a/tests/test_game.py
+++ b/tests/test_game.py
@@ -1,0 +1,65 @@
+import types
+import pyxel
+from tests.helpers import DummyGame
+from firstshot.game_data import GameData
+from firstshot.constants import SCENE_SELECT_PILOT
+from firstshot.logic.dialog import display_exit_dialog
+
+
+class SceneStub:
+    def __init__(self):
+        self.started = False
+        self.updated = False
+    def start(self):
+        self.started = True
+    def update(self):
+        self.updated = True
+    def draw(self):
+        pass
+
+
+class GameForTest(DummyGame):
+    def __init__(self):
+        super().__init__()
+        self.scenes = {"a": SceneStub(), "b": SceneStub()}
+        self.game_data.scene_name = "a"
+        self.game_data.background = types.SimpleNamespace(update=lambda: None)
+
+    def change_scene(self, scene_name):
+        self.changed_scene_to = scene_name
+        self.game_data.scene_name = scene_name
+        self.scenes[scene_name].start()
+
+    def update(self):
+        if not self.game_data.is_exit_mode and pyxel.btnp(pyxel.KEY_E):
+            self.game_data.is_exit_mode = True
+            display_exit_dialog(self)
+            return
+        if self.game_data.is_exit_mode:
+            return
+        self.scenes[self.game_data.scene_name].update()
+        if self.game_data.scene_name != SCENE_SELECT_PILOT:
+            self.game_data.background.update()
+
+
+def test_change_scene_calls_start():
+    game = GameForTest()
+    game.change_scene("b")
+    assert game.game_data.scene_name == "b"
+    assert game.scenes["b"].started
+
+
+def test_game_update_handles_exit():
+    game = GameForTest()
+    pyxel.set_btnp(pyxel.KEY_E, True)
+    called = {}
+    def fake_dialog(g):
+        called['x'] = True
+    display_exit_dialog_orig = display_exit_dialog
+    try:
+        globals()['display_exit_dialog'] = fake_dialog
+        game.update()
+        assert called
+        assert game.game_data.is_exit_mode
+    finally:
+        globals()['display_exit_dialog'] = display_exit_dialog_orig

--- a/tests/test_scenes.py
+++ b/tests/test_scenes.py
@@ -1,0 +1,93 @@
+import types, pygame
+pygame.mixer = types.SimpleNamespace(music=types.SimpleNamespace(stop=lambda *a, **k: None, load=lambda *a, **k: None, set_volume=lambda *a, **k: None, play=lambda *a, **k: None))
+import pyxel
+from tests.helpers import DummyGame
+from firstshot.constants import (
+    SCENE_PLAY_STAGE_TWO,
+    SCENE_PLAY_STAGE_ONE,
+    SCENE_SELECT_PILOT,
+    SCENE_TITLE,
+    GAMEOVER_DISPLAY_TIME,
+)
+from firstshot.scenes.scenes_play_stage import PlayScene, StageOneScene, StageTwoScene
+from firstshot.scenes.select_pilot_scene import SelectPilotScene
+from firstshot.scenes.title_scene import TitleScene
+from firstshot.scenes.gameover_scene import GameoverScene
+from firstshot.scenes.background_scene import Background
+
+
+def test_play_scene_update_increments_time():
+    game = DummyGame()
+    scene = PlayScene(game)
+    scene.start()
+    scene.update()
+    assert game.game_data.play_time == 1
+
+
+def test_stage_one_scene_boss_transition():
+    game = DummyGame()
+    scene = StageOneScene(game)
+    scene.start()
+    game.boss_state.destroyed = True
+    scene.update()
+    assert game.changed_scene_to == SCENE_PLAY_STAGE_TWO
+
+
+def test_stage_one_scene_activate_boss():
+    game = DummyGame()
+    scene = StageOneScene(game)
+    scene.start()
+    game.game_data.play_time = 180
+    scene.update()
+    assert game.boss_state.active
+
+
+def test_stage_two_scene_activate_boss():
+    game = DummyGame()
+    scene = StageTwoScene(game)
+    scene.start()
+    game.game_data.play_time = 300
+    scene.update()
+    assert game.boss_state.active
+
+
+def test_select_pilot_scene_input_and_start_game():
+    game = DummyGame()
+    scene = SelectPilotScene(game)
+    scene.start()
+    pyxel.set_btnp(pyxel.KEY_RIGHT, True)
+    scene.update()
+    assert scene.pilot_kind == 1
+    pyxel.set_btnp(pyxel.KEY_RETURN, True)
+    scene.update()
+    assert game.changed_scene_to == SCENE_PLAY_STAGE_ONE
+    assert game.player_state.pilot_kind == 1
+
+
+def test_title_scene_start_game():
+    game = DummyGame()
+    scene = TitleScene(game)
+    pyxel.set_btnp(pyxel.KEY_RETURN, True)
+    scene.update()
+    assert game.changed_scene_to == SCENE_SELECT_PILOT
+
+
+def test_gameover_scene_timer_and_transition():
+    game = DummyGame()
+    scene = GameoverScene(game)
+    scene.start()
+    assert game.display_timer == GAMEOVER_DISPLAY_TIME
+    scene.update()
+    assert game.display_timer == GAMEOVER_DISPLAY_TIME - 1
+    game.display_timer = 0
+    scene.update()
+    assert game.changed_scene_to == SCENE_TITLE
+
+
+def test_background_update_loops():
+    game = DummyGame()
+    bg = Background(game)
+    x, y, vy = bg.stars[0]
+    bg.stars[0] = (x, pyxel.height + 1, vy)
+    bg.update()
+    assert bg.stars[0][1] < pyxel.height


### PR DESCRIPTION
## Summary
- create pyxel stub and helpers for easier testing
- add comprehensive unit tests for entities, scenes, dialog, and game logic

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68416bbcfebc832880edd96225a95995