### PR TITLE
Add aimed and random enemy lasers

### DIFF
--- a/firstshot/entities/__init__.py
+++ b/firstshot/entities/__init__.py
@@ -7,4 +7,5 @@
 # のようにまとめてインポートできるようにする
 from .blast import Blast
 from .bullet import Bullet
+from .laser import Laser
 from .player import Player

--- a/firstshot/entities/enemies/enemy_stage2_boss_right.py
+++ b/firstshot/entities/enemies/enemy_stage2_boss_right.py
@@ -2,7 +2,7 @@ import pyxel
 
 from firstshot.constants import CLEAR_COLOR
 
-from firstshot.entities import Bullet, Blast
+from firstshot.entities import Bullet, Blast, Laser
 from firstshot.entities.enemies import Enemy
 
 
@@ -65,6 +65,16 @@ class StageTwoBossRight(Enemy):
         if self.life_time % 90 == 0 or self.life_time % 92 == 0 or self.life_time % 94 == 0:
             player_angle = self.calc_player_angle(self.x + 32, self.y + 32)
             Bullet(self.game, Bullet.SIDE_ENEMY, self.x + 32, self.y + 32, player_angle, 7)
+
+        # 一定時間毎に自機を狙ったレーザーを発射する
+        if self.life_time % 120 == 0:
+            angle = self.calc_player_angle(self.x + 32, self.y + 32)
+            Laser(self.game, self.x + 32, self.y + 80, angle, 100, 30)
+
+        # 一定時間毎にランダムな方向へレーザーを発射する
+        if self.life_time % 170 == 0:
+            angle = pyxel.rndi(0, 359)
+            Laser(self.game, self.x + 32, self.y + 80, angle, 100, 30)
 
 
     # 敵を描画する

--- a/firstshot/entities/laser.py
+++ b/firstshot/entities/laser.py
@@ -1,0 +1,29 @@
+try:
+    import pyxel
+except ImportError:  # pragma: no cover - pyxel is unavailable during tests
+    pyxel = None
+
+class Laser:
+    """Laser attack fired in a specific direction."""
+
+    def __init__(self, game, x, y, angle, length, duration):
+        self.game = game
+        self.x = x
+        self.y = y
+        self.angle = angle
+        self.length = length
+        self.timer = duration
+        self.hit_area = (0, 0, 2, length)
+        game.enemy_state.bullets.append(self)
+
+    def update(self):
+        if self.timer > 0:
+            self.timer -= 1
+        if self.timer <= 0 and self in self.game.enemy_state.bullets:
+            self.game.enemy_state.bullets.remove(self)
+
+    def draw(self):
+        if pyxel is not None:
+            end_x = self.x + pyxel.cos(self.angle) * self.length
+            end_y = self.y + pyxel.sin(self.angle) * self.length
+            pyxel.line(self.x, self.y, end_x, end_y, 8)

--- a/pyxel/__init__.py
+++ b/pyxel/__init__.py
@@ -1,0 +1,24 @@
+import math
+import random
+
+width = 256
+height = 256
+
+cos = lambda a: math.cos(math.radians(a))
+sin = lambda a: math.sin(math.radians(a))
+atan2 = lambda y, x: math.degrees(math.atan2(y, x))
+
+def line(*args, **kwargs):
+    pass
+
+def rect(*args, **kwargs):
+    pass
+
+def blt(*args, **kwargs):
+    pass
+
+def play(*args, **kwargs):
+    pass
+
+def rndi(a, b):
+    return random.randint(a, b)

--- a/tests/test_laser.py
+++ b/tests/test_laser.py
@@ -1,0 +1,29 @@
+import os, sys
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from firstshot.entities.laser import Laser
+
+class DummyEnemyState:
+    def __init__(self):
+        self.enemies = []
+        self.bullets = []
+        self.blasts = []
+
+class DummyGame:
+    def __init__(self):
+        self.enemy_state = DummyEnemyState()
+
+def test_laser_removed_after_duration():
+    game = DummyGame()
+    laser = Laser(game, 0, 0, 90, 10, 2)
+    assert laser in game.enemy_state.bullets
+    laser.update()
+    assert laser in game.enemy_state.bullets
+    laser.update()
+    assert laser not in game.enemy_state.bullets
+
+
+def test_laser_stores_angle():
+    game = DummyGame()
+    laser = Laser(game, 0, 0, 45, 10, 1)
+    assert laser.angle == 45


### PR DESCRIPTION
## Summary
- implement more versatile `Laser` class that fires in any direction
- StageTwoBossRight now fires lasers aimed at the player and at random angles
- add pyxel stub for tests
- update unit tests for new Laser API

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684174771a688328bb41419d7c4200b0