### PR TITLE
Add fade-out transitions

### DIFF
--- a/firstshot/scenes/gameover_scene.py
+++ b/firstshot/scenes/gameover_scene.py
@@ -1,6 +1,13 @@
 import pyxel
 
-from firstshot.constants import SCENE_TITLE, GAMEOVER_DISPLAY_TIME, SCREEN_WIDTH, SCREEN_HEIGHT, BGM_GAME_OVER
+from firstshot.constants import (
+    SCENE_TITLE,
+    GAMEOVER_DISPLAY_TIME,
+    SCREEN_WIDTH,
+    SCREEN_HEIGHT,
+    BGM_GAME_OVER,
+    COLOR_BLACK,
+)
 
 
 # ゲームオーバー画面クラス
@@ -31,6 +38,10 @@ class GameoverScene:
 
     def draw(self):
         """画面の描画処理。"""
+        # 画面を黒でクリアしフェードアウト用の dither を設定
+        alpha = self.game.fade_alpha if self.game.is_fading else 1.0
+        pyxel.cls(COLOR_BLACK)
+        pyxel.dither(alpha)
         # 背景を描画する
         pyxel.blt(0, 0, 1, 0, 0, SCREEN_WIDTH, SCREEN_HEIGHT)
         # ゲームオーバー文字を描画する

--- a/firstshot/scenes/scenes_play_stage/play_scene.py
+++ b/firstshot/scenes/scenes_play_stage/play_scene.py
@@ -75,6 +75,10 @@ class PlayScene:
 
     def draw(self):
         """ゲームプレイ中の描画処理。"""
+        # フェードアウト用の dither を設定
+        alpha = self.game.fade_alpha if self.game.is_fading else 1.0
+        pyxel.cls(COLOR_BLACK)
+        pyxel.dither(alpha)
         # ステージ背景を描画する
         pyxel.blt(0, 0, 1, 0, 0, SCREEN_WIDTH, SCREEN_HEIGHT)
 

--- a/firstshot/scenes/select_pilot_scene.py
+++ b/firstshot/scenes/select_pilot_scene.py
@@ -69,8 +69,10 @@ class SelectPilotScene:
 
     def draw(self):
         """画面の描画処理。"""
-        # 画面をクリアする
+        # フェードアウト用の dither を設定し画面をクリア
+        alpha = self.game.fade_alpha if self.game.is_fading else 1.0
         pyxel.cls(COLOR_BLACK)
+        pyxel.dither(alpha)
         # パイロットの表示
         pyxel.blt(0, 0, self.pilot_image, 0, 0, SCREEN_WIDTH, 200)
         # メッセージの表示

--- a/firstshot/scenes/title_scene.py
+++ b/firstshot/scenes/title_scene.py
@@ -1,6 +1,12 @@
 import pyxel
 
-from firstshot.constants import SCENE_SELECT_PILOT, SCREEN_WIDTH, SCREEN_HEIGHT, BGM_TITLE
+from firstshot.constants import (
+    SCENE_SELECT_PILOT,
+    SCREEN_WIDTH,
+    SCREEN_HEIGHT,
+    BGM_TITLE,
+    COLOR_BLACK,
+)
 
 
 # タイトル画面クラス
@@ -34,5 +40,9 @@ class TitleScene:
 
     def draw(self):
         """画面の描画処理。"""
+        # 画面を黒でクリアし、フェードアウト用の dither を設定
+        alpha = self.game.fade_alpha if self.game.is_fading else 1.0
+        pyxel.cls(COLOR_BLACK)
+        pyxel.dither(alpha)
         # タイトル画面を表示
         pyxel.blt(0, 0, 2, 0, 0, SCREEN_WIDTH, SCREEN_HEIGHT, 0)


### PR DESCRIPTION
## Summary
- implement global fade-out effect on scene changes
- apply fade parameters during drawing of existing scenes

## Testing
- `pytest -q` *(fails: ImportError: libSDL2-2.0.so.0)*

------
https://chatgpt.com/codex/tasks/task_e_68444db303508328846f1e905cd14c70