### PR TITLE
Implement Stage 3 enemy classes

### DIFF
--- a/firstshot/entities/enemies/__init__.py
+++ b/firstshot/entities/enemies/__init__.py
@@ -8,3 +8,8 @@ from .enemy_robot_player_shooter import RobotPlayerShooter
 from .enemy_stage2_boss_left import StageTwoBossLeft
 from .enemy_stage2_boss_right import StageTwoBossRight
 from .enemy_zigzag import Zigzag
+from .enemy_burst_shooter import BurstShooter
+from .enemy_sine_shooter import SineShooter
+from .enemy_spiral_shooter import SpiralShooter
+from .enemy_stage3_boss import StageThreeBoss
+

--- a/firstshot/entities/enemies/enemy_burst_shooter.py
+++ b/firstshot/entities/enemies/enemy_burst_shooter.py
@@ -1,0 +1,41 @@
+"""
+ステージ3用の敵キャラクター: BurstShooter の定義
+
+停止と連射を繰り返す特徴を持つ敵を実装するモジュール。
+"""
+import pyxel
+
+from firstshot.constants import COLOR_BLACK
+from firstshot.entities import Bullet
+from firstshot.entities.enemies import Enemy
+
+
+class BurstShooter(Enemy):
+    """一定間隔で多方向へ弾を放つ敵。"""
+
+    def update(self):
+        """敵の挙動を更新する。"""
+        self.add_life_time()
+
+        # 画面上部へ到達するまでは前進
+        if self.y < 40:
+            self.y += 1.0
+        else:
+            # 停止しつつ定期的に弾を連射する
+            if self.life_time % 60 == 0:
+                for i in range(8):
+                    Bullet(
+                        self.game,
+                        Bullet.SIDE_ENEMY,
+                        self.x + 6,
+                        self.y + 6,
+                        pyxel.radians(i * 45),
+                        2,
+                    )
+
+        self.delete_out_enemy()
+
+    def draw(self):
+        """敵を描画する。"""
+        pyxel.blt(self.x, self.y, 0, 64, 20, 12, 12, COLOR_BLACK)
+

--- a/firstshot/entities/enemies/enemy_sine_shooter.py
+++ b/firstshot/entities/enemies/enemy_sine_shooter.py
@@ -1,0 +1,39 @@
+"""
+ステージ3用の敵キャラクター: SineShooter の定義
+
+正弦波を描く軌道で移動しながら弾を撃つ敵を実装するモジュール。
+"""
+import pyxel
+
+from firstshot.constants import COLOR_BLACK
+from firstshot.entities import Bullet
+from firstshot.entities.enemies import Enemy
+
+
+class SineShooter(Enemy):
+    """正弦波運動を行う小型敵。"""
+
+    def __init__(self, game, score, exp, armor, x, y, hit_area_x, hit_area_y):
+        """基底クラスの初期化に加えて初期位置を記憶する。"""
+        super().__init__(game, score, exp, armor, x, y, hit_area_x, hit_area_y)
+        self.base_x = x
+
+    def update(self):
+        """敵の挙動を更新する。"""
+        self.add_life_time()
+
+        # 正弦波に沿って左右へ移動する
+        self.x = self.base_x + pyxel.sin(self.life_time * 0.1) * 20
+        self.y += 0.8
+
+        # 一定間隔でプレイヤーを狙って弾を発射する
+        if self.life_time % 40 == 0:
+            angle = self.calc_player_angle(self.x, self.y)
+            Bullet(self.game, Bullet.SIDE_ENEMY, self.x, self.y, angle, 2)
+
+        self.delete_out_enemy()
+
+    def draw(self):
+        """敵を描画する。"""
+        pyxel.blt(self.x, self.y, 0, 52, 20, 12, 12, COLOR_BLACK)
+

--- a/firstshot/entities/enemies/enemy_spiral_shooter.py
+++ b/firstshot/entities/enemies/enemy_spiral_shooter.py
@@ -1,0 +1,35 @@
+"""
+ステージ3用の敵キャラクター: SpiralShooter の定義
+
+螺旋状の弾幕を放つ移動型敵を実装するモジュール。
+"""
+import pyxel
+
+from firstshot.constants import COLOR_BLACK
+from firstshot.entities import Bullet
+from firstshot.entities.enemies import Enemy
+
+
+class SpiralShooter(Enemy):
+    """螺旋状に弾を放つステージ3用の雑魚敵クラス。"""
+
+    def update(self):
+        """敵の挙動を更新する。"""
+        # 生存時間を増加させる
+        self.add_life_time()
+
+        # 徐々に画面下へ移動する
+        self.y += 0.5
+
+        # 5フレーム毎に弾を回転させながら発射
+        if self.life_time % 5 == 0:
+            angle = pyxel.radians(self.life_time * 10 % 360)
+            Bullet(self.game, Bullet.SIDE_ENEMY, self.x + 4, self.y + 4, angle, 2)
+
+        # 画面外に出たら削除
+        self.delete_out_enemy()
+
+    def draw(self):
+        """敵を描画する。"""
+        pyxel.blt(self.x, self.y, 0, 40, 20, 12, 12, COLOR_BLACK)
+

--- a/firstshot/entities/enemies/enemy_stage3_boss.py
+++ b/firstshot/entities/enemies/enemy_stage3_boss.py
@@ -1,0 +1,51 @@
+"""
+ステージ3用ボスキャラクターの定義。
+
+複数の攻撃パターンを組み合わせた大型の敵を表す。
+"""
+import pyxel
+
+from firstshot.constants import COLOR_BLACK
+from firstshot.entities import Bullet
+from firstshot.entities.enemies import Enemy
+
+
+class StageThreeBoss(Enemy):
+    """ステージ3で登場するボスキャラクター。"""
+
+    def add_damage(self):
+        """ボスがダメージを受けた際の処理。"""
+        super().add_damage()
+        # ボスが破壊されたらフラグを立てる
+        if self not in self.game.enemy_state.enemies:
+            self.game.boss_state.destroyed = True
+
+    def update(self):
+        """ボスの挙動を更新する。"""
+        self.add_life_time()
+
+        # 画面上部まで移動する
+        if self.y < 16:
+            self.y += 0.5
+
+        # 定期的に全方向弾
+        if self.life_time % 45 == 0:
+            for i in range(12):
+                Bullet(
+                    self.game,
+                    Bullet.SIDE_ENEMY,
+                    self.x + 32,
+                    self.y + 32,
+                    pyxel.radians(i * 30),
+                    3,
+                )
+
+        # プレイヤー狙いの高速弾
+        if self.life_time % 90 == 0:
+            angle = self.calc_player_angle(self.x + 32, self.y + 32)
+            Bullet(self.game, Bullet.SIDE_ENEMY, self.x + 32, self.y + 32, angle, 5)
+
+    def draw(self):
+        """ボスを描画する。"""
+        pyxel.blt(self.x, self.y, self.game.boss_state.image, 0, 0, 64, 64, COLOR_BLACK)
+


### PR DESCRIPTION
## Summary
- add three new enemy types for stage 3: SpiralShooter, SineShooter and BurstShooter
- implement StageThreeBoss with radial and targeted attacks
- export new classes in `entities.enemies`

## Testing
- `pytest -q` *(fails: ImportError: libSDL2-2.0.so.0)*

------
https://chatgpt.com/codex/tasks/task_e_68446106db208328a9184c9bd8b62288