### PR TITLE
ステージクリア演出を追加

### DIFF
--- a/firstshot/constants.py
+++ b/firstshot/constants.py
@@ -10,6 +10,7 @@ SCENE_LOADING = "loading"  # ローディング画面
 SCENE_PLAY_STAGE_ONE = "play_stage_one"  # ステージ１画面
 SCENE_PLAY_STAGE_TWO = "play_stage_two"  # ステージ２画面
 SCENE_PLAY_STAGE_THREE = "play_stage_three"  # ステージ３画面
+SCENE_STAGE_CLEAR = "stage_clear"  # ステージクリア画面
 SCENE_GAMEOVER = "gameover"  # ゲームオーバー画面
 
 # 画面設定
@@ -90,6 +91,7 @@ BLAST_END_RADIUS = 8
 
 # ゲーム設定
 GAMEOVER_DISPLAY_TIME = 120
+STAGE_CLEAR_DISPLAY_TIME = 150
 STAGE1_BOSS_APPEAR_TIME = 180
 STAGE2_BOSS_APPEAR_TIME = 300
 STAGE3_BOSS_APPEAR_TIME = 600

--- a/firstshot/game.py
+++ b/firstshot/game.py
@@ -6,6 +6,7 @@ from firstshot.constants import (
     SCENE_PLAY_STAGE_ONE,
     SCENE_PLAY_STAGE_TWO,
     SCENE_PLAY_STAGE_THREE,
+    SCENE_STAGE_CLEAR,
     SCENE_GAMEOVER,
     FONT_PATH,
     PALETTE_IMAGE_PATH,
@@ -19,7 +20,7 @@ from firstshot.constants import (
 from firstshot.game_data import PlayerState, EnemyState, BossState, GameData, GameConfig
 from firstshot.logic.dialog import display_exit_dialog
 from firstshot.manager import SoundManager
-from firstshot.scenes import TitleScene, GameoverScene, LoadingScene
+from firstshot.scenes import TitleScene, GameoverScene, LoadingScene, StageClearScene
 from firstshot.scenes.scenes_play_stage import (
     StageOneScene,
     StageTwoScene,
@@ -61,6 +62,7 @@ class Game:
             SCENE_TITLE: TitleScene(self),
             SCENE_SELECT_PILOT: SelectPilotScene(self),
             SCENE_LOADING: LoadingScene(self),
+            SCENE_STAGE_CLEAR: StageClearScene(self),
             SCENE_PLAY_STAGE_ONE: StageOneScene(self),
             SCENE_PLAY_STAGE_TWO: StageTwoScene(self),
             SCENE_PLAY_STAGE_THREE: StageThreeScene(self),

--- a/firstshot/scenes/__init__.py
+++ b/firstshot/scenes/__init__.py
@@ -9,5 +9,6 @@
 from .background_scene import Background  # 背景クラス
 from .gameover_scene import GameoverScene
 from .loading_scene import LoadingScene
+from .stage_clear_scene import StageClearScene
 from .select_pilot_scene import SelectPilotScene
 from .title_scene import TitleScene

--- a/firstshot/scenes/scenes_play_stage/stage_one_scene.py
+++ b/firstshot/scenes/scenes_play_stage/stage_one_scene.py
@@ -11,7 +11,7 @@ from firstshot.constants import (
     ENEMY_SPAWN_MIN,
     BOSS_ALERT_DURATION,
     BGM_STAGE1, BASE_SCORE_STAGE_ONE, BASE_EXP_STAGE_ONE, BASE_ARMOR_STAGE_ONE, BOSS_SCORE_STAGE_ONE,
-    BOSS_EXP_STAGE_ONE, BOSS_ARMOR_STAGE_ONE, SCENE_LOADING,
+    BOSS_EXP_STAGE_ONE, BOSS_ARMOR_STAGE_ONE, SCENE_LOADING, SCENE_STAGE_CLEAR,
 )
 from firstshot.entities import Player
 from firstshot.entities.enemies.stage1 import Zigzag, AroundShooter, PlayerShooter, StageOneBoss
@@ -56,7 +56,7 @@ class StageOneScene(PlayScene):
         if self.game.boss_state.destroyed:
             # ステージクリアフラグをオンにする
             self.game.game_data.cleared_stage_one = True
-            self.game.change_scene(SCENE_LOADING)
+            self.game.change_scene(SCENE_STAGE_CLEAR)
             return
 
         # 設定時間後にボスフラグをオンにする

--- a/firstshot/scenes/scenes_play_stage/stage_three_scene.py
+++ b/firstshot/scenes/scenes_play_stage/stage_three_scene.py
@@ -17,6 +17,7 @@ from firstshot.constants import (
     BOSS_EXP_STAGE_THREE,
     BOSS_ARMOR_STAGE_THREE,
     SCENE_GAMEOVER,
+    SCENE_STAGE_CLEAR,
 )
 
 # ステージ3のエネミークラス類をインポート
@@ -86,7 +87,7 @@ class StageThreeScene(PlayScene):
         # ボスが撃破済みならステージクリアフラグを立ててゲームオーバーシーンへ遷移
         if self.game.boss_state.destroyed:
             self.game.game_data.cleared_stage_three = True  # ステージ3クリア記録
-            self.game.change_scene(SCENE_GAMEOVER)          # ゲームオーバー（クリア）へ
+            self.game.change_scene(SCENE_STAGE_CLEAR)
             return
 
         # 一定時間経過後にボス出現フラグをオン

--- a/firstshot/scenes/scenes_play_stage/stage_two_scene.py
+++ b/firstshot/scenes/scenes_play_stage/stage_two_scene.py
@@ -16,6 +16,7 @@ from firstshot.constants import (
     BOSS_EXP_STAGE_TWO,
     BOSS_ARMOR_STAGE_TWO,
     SCENE_LOADING,
+    SCENE_STAGE_CLEAR,
 )
 from firstshot.entities.enemies.stage2 import RobotFollow, RobotAroundShooter, RobotPlayerShooter, StageTwoBossLeft, \
     StageTwoBossRight
@@ -62,7 +63,7 @@ class StageTwoScene(PlayScene):
         # ボス撃破フラグがTrueの場合、次のステージに移行する
         if self.game.boss_state.destroyed:
             self.game.game_data.cleared_stage_two = True
-            self.game.change_scene(SCENE_LOADING)
+            self.game.change_scene(SCENE_STAGE_CLEAR)
             return
 
         # 設定時間経過後にボスフラグをオンにする

--- a/firstshot/scenes/stage_clear_scene.py
+++ b/firstshot/scenes/stage_clear_scene.py
@@ -1,0 +1,48 @@
+"""ステージクリア画面モジュール
+
+各ステージクリア後に"STAGE CLEAR"を表示し、次シーンへ遷移する。"""
+
+import pygame
+import pyxel
+
+from firstshot.constants import (
+    COLOR_BLACK,
+    SCREEN_WIDTH,
+    SCREEN_HEIGHT,
+    SCENE_LOADING,
+    SCENE_GAMEOVER,
+    STAGE_CLEAR_DISPLAY_TIME,
+)
+
+
+class StageClearScene:
+    """ステージクリアメッセージを表示するシーン。"""
+
+    def __init__(self, game):
+        """インスタンスを初期化する。"""
+        self.game = game
+
+    def start(self):
+        """シーン開始時の初期化処理。"""
+        pygame.mixer.music.stop()
+        self.game.display_timer = STAGE_CLEAR_DISPLAY_TIME
+
+    def update(self):
+        """毎フレームの更新処理。"""
+        if self.game.display_timer > 0:
+            self.game.display_timer -= 1
+        else:
+            if self.game.game_data.cleared_stage_three:
+                self.game.change_scene(SCENE_GAMEOVER)
+            else:
+                self.game.change_scene(SCENE_LOADING)
+
+    def draw(self):
+        """画面描画処理。"""
+        alpha = self.game.fade_alpha if self.game.is_fading else 1.0
+        pyxel.cls(COLOR_BLACK)
+        pyxel.dither(alpha)
+        text = "STAGE CLEAR"
+        x = (SCREEN_WIDTH - len(text) * 4) // 2
+        y = SCREEN_HEIGHT // 2
+        pyxel.text(x, y, text, 8, self.game.font)


### PR DESCRIPTION
## Summary
- 5秒間"STAGE CLEAR"を表示する`StageClearScene`を追加
- クリア後は`StageClearScene`へ遷移するよう各ステージを修正
- `StageClearScene`完了後にローディング/ゲームオーバーへ遷移
- シーン定数`SCENE_STAGE_CLEAR`と表示時間`STAGE_CLEAR_DISPLAY_TIME`を追加
- ゲーム初期化で`StageClearScene`を登録

## Testing
- `pytest -q` *(fails: ImportError libSDL2-2.0.so.0)*

------
https://chatgpt.com/codex/tasks/task_e_6845056d56008328b68a248b20c33119