### PR TITLE
Implement Game Clear Scene

### DIFF
--- a/firstshot/constants.py
+++ b/firstshot/constants.py
@@ -11,6 +11,7 @@ SCENE_PLAY_STAGE_ONE = "play_stage_one"  # ステージ１画面
 SCENE_PLAY_STAGE_TWO = "play_stage_two"  # ステージ２画面
 SCENE_PLAY_STAGE_THREE = "play_stage_three"  # ステージ３画面
 SCENE_GAMEOVER = "gameover"  # ゲームオーバー画面
+SCENE_GAME_CLEAR = "game_clear"  # ゲームクリア画面
 
 # 画面設定
 SCREEN_WIDTH = 256
@@ -33,6 +34,7 @@ TITLE_IMAGE_PATH = "assets/background/title.png"
 STAGE1_BG_PATH = "assets/background/stage.png"
 STAGE2_BG_PATH = "assets/background/stage2.png"
 STAGE3_BG_PATH = "assets/background/stage3.png"
+GAME_CLEAR_IMAGE_PATH = "assets/background/game_clear.png"
 STAGE1_ENEMY_IMAGE = "assets/enemy/enemy_sheet2_size64.png"
 STAGE1_BOSS_IMAGE = "assets/enemy/boss_sheet_size192.png"
 STAGE2_ENEMY_IMAGE = "assets/enemy/enemy_stage2.png"

--- a/firstshot/game.py
+++ b/firstshot/game.py
@@ -7,6 +7,7 @@ from firstshot.constants import (
     SCENE_PLAY_STAGE_TWO,
     SCENE_PLAY_STAGE_THREE,
     SCENE_GAMEOVER,
+    SCENE_GAME_CLEAR,
     FONT_PATH,
     PALETTE_IMAGE_PATH,
     RESOURCE_FILE,
@@ -19,7 +20,12 @@ from firstshot.constants import (
 from firstshot.game_data import PlayerState, EnemyState, BossState, GameData, GameConfig
 from firstshot.logic.dialog import display_exit_dialog
 from firstshot.manager import SoundManager
-from firstshot.scenes import TitleScene, GameoverScene, LoadingScene
+from firstshot.scenes import (
+    TitleScene,
+    GameoverScene,
+    GameClearScene,
+    LoadingScene,
+)
 from firstshot.scenes.scenes_play_stage import (
     StageOneScene,
     StageTwoScene,
@@ -65,6 +71,7 @@ class Game:
             SCENE_PLAY_STAGE_TWO: StageTwoScene(self),
             SCENE_PLAY_STAGE_THREE: StageThreeScene(self),
             SCENE_GAMEOVER: GameoverScene(self),
+            SCENE_GAME_CLEAR: GameClearScene(self),
         }  # シーンの辞書
 
         # フェードアウト用のパラメータ

--- a/firstshot/scenes/__init__.py
+++ b/firstshot/scenes/__init__.py
@@ -8,6 +8,7 @@
 
 from .background_scene import Background  # 背景クラス
 from .gameover_scene import GameoverScene
+from .gameclear_scene import GameClearScene
 from .loading_scene import LoadingScene
 from .select_pilot_scene import SelectPilotScene
 from .title_scene import TitleScene

--- a/firstshot/scenes/gameclear_scene.py
+++ b/firstshot/scenes/gameclear_scene.py
@@ -1,0 +1,40 @@
+import pyxel
+
+from firstshot.constants import (
+    SCENE_TITLE,
+    SCREEN_WIDTH,
+    SCREEN_HEIGHT,
+    COLOR_BLACK,
+    GAME_CLEAR_IMAGE_PATH,
+)
+
+
+class GameClearScene:
+    """ゲームクリア画面を制御するクラス。"""
+
+    def __init__(self, game):
+        """GameClearScene のインスタンスを初期化する。"""
+        self.game = game
+        # ゲームクリア画面に表示するイメージを格納する Image オブジェクト
+        self.clear_image = pyxel.Image(SCREEN_WIDTH, SCREEN_HEIGHT)
+
+    def start(self):
+        """ゲームクリア画面の開始処理を行う。"""
+        # リソースからゲームクリア画像を読み込み表示用イメージに設定
+        pyxel.Image.load(self.clear_image, 0, 0, GAME_CLEAR_IMAGE_PATH)
+
+        # プレイヤーインスタンスを削除しておく
+        self.game.player_state.instance = None
+
+    def update(self):
+        """毎フレームの更新処理を実行する。"""
+        # ENTER キー入力でタイトル画面へ戻る
+        if pyxel.btnp(pyxel.KEY_RETURN):
+            self.game.change_scene(SCENE_TITLE)
+
+    def draw(self):
+        """ゲームクリア画面を描画する。"""
+        alpha = self.game.fade_alpha if self.game.is_fading else 1.0
+        pyxel.cls(COLOR_BLACK)
+        pyxel.dither(alpha)
+        pyxel.blt(0, 0, self.clear_image, 0, 0, SCREEN_WIDTH, SCREEN_HEIGHT)

--- a/firstshot/scenes/scenes_play_stage/stage_three_scene.py
+++ b/firstshot/scenes/scenes_play_stage/stage_three_scene.py
@@ -16,7 +16,7 @@ from firstshot.constants import (
     BOSS_SCORE_STAGE_THREE,
     BOSS_EXP_STAGE_THREE,
     BOSS_ARMOR_STAGE_THREE,
-    SCENE_GAMEOVER,
+    SCENE_GAME_CLEAR,
 )
 
 # ステージ3のエネミークラス類をインポート
@@ -88,7 +88,7 @@ class StageThreeScene(PlayScene):
             self.game.game_data.cleared_stage_three = True  # ステージ3クリア記録
 
         if self.game.game_data.cleared_stage_three:
-            super().stagestruck(SCENE_GAMEOVER)
+            super().stagestruck(SCENE_GAME_CLEAR)
             return
 
         # 一定時間経過後にボス出現フラグをオン


### PR DESCRIPTION
## Summary
- add SCENE_GAME_CLEAR constant and image path
- create GameClearScene to show `game_clear.png`
- register GameClearScene in scene list
- transition to game clear scene after beating stage 3

## Testing
- `pytest -q` *(fails: ImportError: libSDL2-2.0.so.0)*

------
https://chatgpt.com/codex/tasks/task_e_684581668f808328b924c518cbddd462