### PR TITLE
Refactor dialog module imports

### DIFF
--- a/firstshot/logic/__init__.py
+++ b/firstshot/logic/__init__.py
@@ -1,2 +1,3 @@
 from .collision import check_collision
-from .dialog import *
+
+__all__ = ["check_collision"]

--- a/firstshot/logic/dialog.py
+++ b/firstshot/logic/dialog.py
@@ -1,34 +1,45 @@
+"""ゲーム終了確認ダイアログの表示機能を提供するモジュール。
+
+ユーザーがゲーム終了を試みた際に、確認ダイアログを表示して処理を分岐させる。
+Pyxel 側でウィンドウを生成しているため ``tkinter`` とは直接連携せず、
+一時的に ``Tk()`` を生成してメッセージボックスのみ利用する。
+"""
+
 import pyxel
+import tkinter as tk
+from tkinter import messagebox
 
 from firstshot.constants import EXIT_DIALOG_TITLE, EXIT_DIALOG_MESSAGE
 
 
 # ゲーム終了確認のダイアログを表示
 def display_exit_dialog(game):
-    """
-    Eキーを押したときに呼ばれるメソッド。
-    Tkinterで「本当に終了しますか？」ダイアログを出し、
-    はいなら pyxel.quit()、いいえなら self.confirming を False に戻す。
-    """
-    # ── 1. 必要なときだけ Tkinter をインポート ──
-    import tkinter as tk
-    from tkinter import messagebox
+    """終了確認ダイアログを表示してゲーム終了処理を行う。
 
-    # ── 2. ルートウィンドウを作ってすぐに隠す ──
+    Args:
+        game: ゲーム全体の状態を保持する ``Game`` オブジェクト。 ``game.data``
+            から終了フラグを更新する。
+
+    Returns:
+        None
+    """
+
+    # ── 1. ルートウィンドウを作ってすぐに隠す ──
     root = tk.Tk()
     root.withdraw()
+    try:
+        # ── 2. 確認ダイアログを出す ──
+        #   askyesno は True/False を返す
+        result = messagebox.askyesno(
+            title=EXIT_DIALOG_TITLE,
+            message=EXIT_DIALOG_MESSAGE,
+            parent=root,
+        )
+    finally:
+        # ── 3. ダイアログが閉じたら root を完全に破棄 ──
+        root.destroy()
 
-    # ── 3. 確認ダイアログを出す ──
-    #   askyesno は True/False を返す
-    result = messagebox.askyesno(
-        title=EXIT_DIALOG_TITLE,
-        message=EXIT_DIALOG_MESSAGE
-    )
-
-    # ── 4. ダイアログが閉じたら root を完全に破棄 ──
-    root.destroy()
-
-    # ── 5. 結果に応じて処理 ──
+    # ── 4. 結果に応じて処理 ──
     if  result:
         # 「はい」を押された → Pyxel を終了
         pyxel.quit()


### PR DESCRIPTION
## Summary
- refactor exit dialog handling
- avoid importing `tkinter` inside the function
- clean logic package initialization

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6848588dba788328964c0136a7112c78