### PR TITLE
Fix module import path for game entry point

### DIFF
--- a/firstshot/main.py
+++ b/firstshot/main.py
@@ -1,7 +1,32 @@
-# メインモジュール
-# このクラスを実行することでゲームを開始する
+"""ゲーム起動用エントリーポイント。
 
-from game import Game
+このモジュールを ``python main.py`` として実行した場合でも、
+プロジェクト直下の ``firstshot`` パッケージを正しくインポートできる
+ように ``sys.path`` を調整する。
+"""
 
-# ゲームを開始する
-Game()
+from __future__ import annotations
+
+import os
+import sys
+
+
+def _setup_module_path() -> None:
+    """モジュール探索パスを調整する補助関数。"""
+
+    base_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+    if base_dir not in sys.path:
+        sys.path.insert(0, base_dir)
+
+
+def main() -> None:
+    """ゲームを起動する。"""
+
+    _setup_module_path()
+    from firstshot.game import Game
+
+    Game()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- adjust `firstshot/main.py` to handle imports when executed directly

## Testing
- `pytest -q`
- `python firstshot/main.py` *(fails: ImportError: libSDL2-2.0.so.0)*

------
https://chatgpt.com/codex/tasks/task_e_68492b2476108328a0a53bd442126ae9