### PR TITLE
Fix import path for standalone execution

### DIFF
--- a/firstshot/main.py
+++ b/firstshot/main.py
@@ -1,7 +1,20 @@
 # メインモジュール
-# このクラスを実行することでゲームを開始する
+# このモジュールを実行することでゲームを起動する
+"""ゲーム起動用のエントリーポイント。
+
+このスクリプトは ``python firstshot/main.py`` のように直接実行される
+ことを想定している。カレントディレクトリに ``firstshot`` パッケージを
+インストールしていない環境でも、親ディレクトリを ``sys.path`` に
+追加することでモジュールのインポートエラーを回避する。
+"""
+
+import os
+import sys
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
 from firstshot.game import Game
 
-# ゲームを開始する
-Game()
+if __name__ == "__main__":
+    # ゲームを開始する
+    Game()


### PR DESCRIPTION
## Summary
- adjust `firstshot/main.py` to handle running the script directly
- document the entry point and update `sys.path`

## Testing
- `pytest -q`
- `python firstshot/main.py` *(fails: ImportError: libSDL2-2.0.so.0)*

------
https://chatgpt.com/codex/tasks/task_e_68493ed57bd88328a86b8bac8a2e71eb